### PR TITLE
use noble from abandonware

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-var noble = require('noble');
+var noble = require('@abandonware/noble');;
 
 class MiScale extends EventEmitter {
     constructor(macAddr) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "binary-parser": "^1.3.2",
-        "noble": "^1.9.0",
+        "@abandonware/noble": "^1.9.2-5",
         "websocket": "^1.0.26",
         "ws": "^6.0.0"
     },


### PR DESCRIPTION
Changed noble dependency to maintained package @abandonware/noble. @abandonware/noble is a fork of the previous package and it looks like it's compatible. After this dependency change, the node started working for me.